### PR TITLE
Added missing includes (for uintmax_t, ofstream)

### DIFF
--- a/src/impl/autotierfs/config.cpp
+++ b/src/impl/autotierfs/config.cpp
@@ -26,6 +26,7 @@
 #include <45d/config/ConfigSubsectionGuard.hpp>
 #include <regex>
 #include <sstream>
+#include <fstream>
 
 extern "C" {
 #include <sys/statvfs.h>

--- a/src/incl/alert.hpp
+++ b/src/incl/alert.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 /**
  * @brief Class to print logs to either stdout/stderr or the syslog.


### PR DESCRIPTION
Platform:
arch linux (up-to-date @ 12.02.2024), gcc version 13.2.1 20230801 (GCC) 


Fixes following compilation errors:
```
In file included from src/impl/autotierfs/conflicts.cpp:20:
src/incl/alert.hpp:96:34: error: ‘uintmax_t’ has not been declared
   96 |         std::string format_bytes(uintmax_t bytes) const;
      |                                  ^~~~~~~~~
src/incl/alert.hpp:107:29: error: ‘uintmax_t’ has not been declared
  107 |         double format_bytes(uintmax_t bytes, std::string &unit) const;
      |                             ^~~~~~~~~

```

and

```
src/impl/autotierfs/config.cpp:228:25: error: variable ‘std::ofstream f’ has initializer but incomplete type
  228 |         std::ofstream f(config_path.string());
```
